### PR TITLE
Initialize Agno FastAPI starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # backend-ai-agents
+
+A simple FastAPI project demonstrating how to integrate the [Agno](https://docs.agno.com/introduction/agents) agent framework with [OpenAI](https://platform.openai.com/docs/) using the `gpt-4.1-mini` model.
+
+## Installation
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set your OpenAI API key as an environment variable:
+
+```bash
+export OPENAI_API_KEY="YOUR_KEY"
+```
+
+## Running the server
+
+Start the FastAPI app with Uvicorn:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The API exposes a single `/chat` endpoint that accepts a prompt and returns the model response.
+
+Refer to the [FastAPI installation guide](https://fastapi.tiangolo.com/#installation) for additional details.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from agno.agent import Agent
+from agno.models.openai.chat import OpenAIChat
+
+# Initialize the agent using OpenAI's GPT-4.1-mini model
+chat_agent = Agent(model=OpenAIChat(id="gpt-4.1-mini"))
+
+app = FastAPI(title="Agno AI Agent")
+
+class Prompt(BaseModel):
+    prompt: str
+
+@app.post("/chat")
+async def chat(prompt: Prompt):
+    """Generate a response using the configured AI agent."""
+    run_response = chat_agent.run(prompt.prompt)
+    return {"response": run_response.content}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+openai
+agno


### PR DESCRIPTION
## Summary
- add FastAPI app using Agno agent and OpenAI's gpt-4.1-mini model
- document how to install dependencies and run the server
- include requirements.txt for project dependencies

## Testing
- `python -m py_compile app/main.py`
- `uvicorn --help | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6887e4e4f750832a8531542d703073cf